### PR TITLE
fix fetchExperiments error handling

### DIFF
--- a/ProbaSdk/src/main/java/ai/proba/probasdk/ProbaHandler.kt
+++ b/ProbaSdk/src/main/java/ai/proba/probasdk/ProbaHandler.kt
@@ -24,7 +24,7 @@ internal class ProbaHandler : Handler(Looper.getMainLooper()) {
     }
 
     internal fun sendError(listener: ProbaSdk.OnErrorListener, th: Throwable) {
-        obtainMessage(ON_SUCCESS, Result(null, listener, th)).sendToTarget();
+        obtainMessage(ON_ERROR, Result(null, listener, th)).sendToTarget();
     }
 
     class Result(

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ ext {
     minSdkVersion = 14
     targetSdkVersion = 30
 
-    probaSdkVersion = "0.1.0"
+    probaSdkVersion = "0.1.1"
 }
 
 subprojects {


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Фикс логики обработки ошибок при запросе экспериментов.

**Суть ошибки.** Ранее всегда в `handler`'е отправлялось сообщение `ON_SUCCESS`, даже в случае ошибки. Соответственно, мы всегда пытались вызвать `onSuccessListener`, но в случае ошибки (вызов метода `sendError`) мы не прокидываем `onSuccessListener` в `handler`. В итоге получается, что ни один из листенеров не срабатывает.

**Суть фикса.** Теперь мы при возникновении ошибки (вызов метода `sendError`) шлем сообщение `ON_ERROR` тем самым попадая на вызов метода `onErrorListener`, который мы прокинули в метод `sendError`.

P.S. Также обновил версию sdk на **0.1.1**